### PR TITLE
Add github repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rewiremock",
   "version": "3.4.2",
   "description": "Easy and es6 compatible dependency mocking tool.",
+  "repository": { 
+    "url": "theKashey/rewiremock"
+  },
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Being able to quickly access a package's git repository is helpful for checking the package's quality and longevity. Without this field the github repo link doesn't show up on npmjs.com.