### PR TITLE
Fix interceptor path on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewiremock",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Advanced dependency mocking device.",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/webpack/plugin.js
+++ b/webpack/plugin.js
@@ -1,7 +1,7 @@
 const {relative} = require("path");
 const {ConcatSource} = require("webpack-sources");
 
-const file = './' + relative(process.cwd(), __dirname + '/interceptor.js');
+const file = './' + relative(process.cwd(), __dirname + '/interceptor.js').replace(/\\/g, '/');
 
 const injectString = "/***/if(typeof __webpack_require__!=='undefined'){__webpack_require__ = __webpack_require__('" + file + "')(__webpack_require__, module);}\n";
 
@@ -9,7 +9,7 @@ class RewiremockPlugin {
   apply(compiler) {
     compiler.plugin('compilation', function (compilation) {
 
-      compilation.moduleTemplate.plugin("render", function (moduleSource) {
+      compilation.moduleTemplate.plugin('render', function (moduleSource) {
         const source = new ConcatSource();
         source.add(injectString);
         source.add(moduleSource);


### PR DESCRIPTION
On Windows path to `interceptor.js` was generated with `\` so I have made quick fix.