### PR TITLE
Catch TypeError: Cannot read property 'call' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewiremock",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "Advanced dependency mocking device.",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/webpack/plugin.js
+++ b/webpack/plugin.js
@@ -6,7 +6,10 @@ const normalizePath = a => a[0] === '.' ? a : './' + a;
 const file = normalizePath(relative(process.cwd(), __dirname + '/interceptor.js').replace(/\\/g, '/'));
 
 const injectString = `/***/if(typeof __webpack_require__!=='undefined') {
-   var rewiremockInterceptor = __webpack_require__('${file}');
+   try {
+     var rewiremockInterceptor = __webpack_require__('${file}');
+   } catch (e) {}
+   
    if (rewiremockInterceptor && rewiremockInterceptor.default) { 
      __webpack_require__ = rewiremockInterceptor.default(__webpack_require__, module);
    }


### PR DESCRIPTION
#### The issue
TypeError: Cannot read property 'call' of undefined

Caused by webpack. Sometimes is does not include some important files. To solve this problem just import('rewiremock/webpack/interceptor') in scaffolding. The problem is simply - this file does not exists in the bundle.

#### My idea
The above error is described in readme, but the suggested solution is not that perfect. 
I could always repro the error if:
* rewiremock plugin is added to webpack config
* test code does not import rewiremock

This case is so common. The following are some possible scenarios:
* I may not need to mock anything for now, but I want the mocking infrastructure there. 
* I have a project with some tests and mocks working well. But I dont want to get this error if I comment out all the test files.
* Similar case would be, I have a number of loaders for different file types in webpack config, but I may not actually have all the file types. 

So it would be better if the rewiremock plugin does not make any assumption that rewiremock must exist in the bundle. In this way we decouple the infrastructure and the application code, and increase flexibility.


#### The change
The change is simple, just swallow the error. Everything goes well even if I dont import rewiremock in my test code. My tests runs and pass.

#### Verification
Verified in my local enviroment








