### PR TITLE
Make webpack/interceptor ES5 and add lint for it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,6 @@
     "node": true,
     "es6": true,
     "mocha": true
-  }
+  },
+  "root": true
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build5": "BABEL_ENV=cjs babel src -d lib && cp src/index.js.flow lib/index.js.flow",
     "build6": "BABEL_ENV=ejs babel src -d es && cp src/index.js.flow es/index.js.flow",
     "prepublish": "npm run build",
-    "lint": "eslint src",
-    "lint:fix": "eslint src tests --fix"
+    "lint": "eslint src webpack",
+    "lint:fix": "eslint src webpack tests --fix"
   },
   "repository": {
     "type": "git",

--- a/webpack/interceptor/.eslintrc
+++ b/webpack/interceptor/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "root": true
+}

--- a/webpack/interceptor/index.js
+++ b/webpack/interceptor/index.js
@@ -1,7 +1,7 @@
-const requires = [];
-let Module;
+var requires = [];
+var Module;
 
-const loader = function baseLoader(request, parent, isMain) {
+var loader = function baseLoader(request/*, parent, isMain*/) {
   return requires[requires.length - 1](request);
 };
 
@@ -9,7 +9,7 @@ const loader = function baseLoader(request, parent, isMain) {
 function interceptor(superRequire, parentModule) {
   function RQ(fileName) {
     interceptor.pushLoader(superRequire);
-    const result = Module
+    var result = Module
       ? Module._load(fileName, parentModule)
       : loader(fileName, parentModule);
 
@@ -17,7 +17,7 @@ function interceptor(superRequire, parentModule) {
     return result;
   }
 
-  Object.getOwnPropertyNames(superRequire).forEach(key => {
+  Object.getOwnPropertyNames(superRequire).forEach(function(key) {
     try {
       RQ[key] = superRequire[key]
     } catch (e) {
@@ -27,15 +27,15 @@ function interceptor(superRequire, parentModule) {
   return RQ;
 }
 
-interceptor.pushLoader = (loader) => {
+interceptor.pushLoader = function(loader) {
   requires.push(loader)
 };
 
-interceptor.popLoader = (loader) => {
+interceptor.popLoader = function(/*loader*/) {
   requires.pop();
 };
 
-interceptor.provideModule = (_Module) => {
+interceptor.provideModule = function(_Module) {
   Module = _Module;
 };
 

--- a/webpack/module.js
+++ b/webpack/module.js
@@ -18,6 +18,7 @@ const Module = {
       return asIndex;
     }
     if (!asFile && !asIs) {
+      // eslint-disable-next-line
       console.warn('rewiremock: ', fileName, 'requested from', parent.i, 'was not found');
     }
     return asFile || fileName;

--- a/webpack/plugin.js
+++ b/webpack/plugin.js
@@ -3,13 +3,13 @@ const {ConcatSource} = require("webpack-sources");
 
 const normalizePath = a => a[0] === '.' ? a : './' + a;
 
-const file = normalizePath(relative(process.cwd(), __dirname + '/interceptor.js').replace(/\\/g, '/'));
+const file = normalizePath(relative(process.cwd(), __dirname + '/interceptor/index.js').replace(/\\/g, '/'));
 
 const injectString = `/***/if(typeof __webpack_require__!=='undefined') {
    try {
      var rewiremockInterceptor = __webpack_require__('${file}');
-   
-     if (rewiremockInterceptor && rewiremockInterceptor.default) { 
+
+     if (rewiremockInterceptor && rewiremockInterceptor.default) {
        __webpack_require__ = rewiremockInterceptor.default(__webpack_require__, module);
      }
    } catch (e) {}
@@ -30,7 +30,7 @@ class RewiremockPlugin {
         // re-hoists mocks
         const firstImport = src.indexOf('/* harmony import');
         if (src.indexOf('rwrmck') > 0 && firstImport > 0) {
-          const match = src.match(/\(function rwrmck\(([\s\S]*)rwrmck\'\);/g);
+          const match = src.match(/\(function rwrmck\(([\s\S]*)rwrmck'\);/g);
           if (match && match.length) {
             moduleSource = [
               src.substr(0, firstImport),
@@ -46,6 +46,6 @@ class RewiremockPlugin {
       });
     });
   }
-};
+}
 
 module.exports = RewiremockPlugin;


### PR DESCRIPTION
This PR fixes #57 . 

For having standalone eslint rule for ES5, `webpack/interceptor.js` is moved to `webpack/interceptor/index.js`.
The content is changed to ES5.

Several ESLint fixes are done for `webpack` folder.