### PR TITLE
Support IE11 - finally done!

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -28,7 +28,7 @@
         ]
       ],
       "plugins": [
-        "transform-object-assign",
+        "transform-runtime",
         [
           "transform-object-rest-spread",
           {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "author": "Anton Korzunov (thekashey@gmail.com)",
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "compare-module-exports": "^2.1.0",
     "lodash.some": "^4.6.0",
     "lodash.template": "^4.4.0",
@@ -87,8 +88,8 @@
     "babel-loader": "7",
     "babel-plugin-dynamic-import-node": "^1.0.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "1.7.0",
     "babel-register": "6.26.0",

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -46,7 +46,7 @@ module.exports = (args) => {
           const {imports, mocks} = node[REGISTRATIONS];
           if (mocks.length) {
 
-            const rewiremock = imports.find(({node}) => node.source.value.indexOf('rewiremock') >= 0);
+            const rewiremock = imports.some(({node}) => node.source.value.indexOf('rewiremock') >= 0);
             if (!rewiremock) {
               /* eslint-disable no-console */
               console.warn('rewiremock not found in imports');

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -15,7 +15,7 @@ const insertMock = (name, mock) => getScope().mocks[name] = mock;
 const resetMock = (name) => insertMock(name, genMock(name));
 
 const pickFrom = (mocks, name) => {
-  const ext = extensions.find(ext => mocks.hasOwnProperty(name + ext));
+  const ext = extensions.filter(ext => mocks.hasOwnProperty(name + ext)).shift();
   if (ext !== undefined) {
     return mocks[name + ext]
   }

--- a/src/module.js
+++ b/src/module.js
@@ -60,7 +60,8 @@ export const pickModuleName = (fileName, parent) => {
     const targetFile = resolve(dirname(getModuleName(parent)), fileName);
     return Object
       .keys(__webpack_modules__)
-      .find(name => name.indexOf(targetFile) > 0);
+      .filter(name => name.indexOf(targetFile) > 0)
+      .shift();
   } else {
     return fileName;
   }
@@ -75,7 +76,7 @@ export const getModuleParents = (module) => module && (module.parent ? [getModul
 export const inParents = (a, b) => {
   const B = getModuleName(b)
   const parents = getModuleParents(a);
-  return !!parents.find(x => x === B);
+  return parents.some(x => x === B);
 }
 
 export default NodeModule;

--- a/src/plugins/_common.js
+++ b/src/plugins/_common.js
@@ -19,7 +19,7 @@ const createPlugin = (plugin) => {
 }
 
 const standardWipeCheck = (stubs, moduleName) => {
-    if (extensions.find(ext => stubs[moduleName + ext]) !== undefined) {
+    if (extensions.some(ext => stubs[moduleName + ext])) {
         return YES;
     }
 };

--- a/src/plugins/relative.js
+++ b/src/plugins/relative.js
@@ -3,12 +3,13 @@ import {inParents} from '../module';
 import { extensions } from "../_common";
 
 const trimKey = (key) => key[0] == '.' ? trimKey(key.substr(1)) : key;
+const endsWith = (a, b) => a.substring(a.length - b.length) === b;
 
 export const relativeWipeCheck = (stubs, moduleName) => {
   if (Object
       .keys(stubs)
       .some(key =>
-        extensions.some( ext => moduleName.endsWith(trimKey(key+ext)))
+        extensions.some( ext => endsWith(moduleName, trimKey(key+ext)))
       )
   ) {
     return YES;

--- a/src/plugins/relative.js
+++ b/src/plugins/relative.js
@@ -7,8 +7,8 @@ const trimKey = (key) => key[0] == '.' ? trimKey(key.substr(1)) : key;
 export const relativeWipeCheck = (stubs, moduleName) => {
   if (Object
       .keys(stubs)
-      .find(key =>
-        extensions.find( ext => moduleName.endsWith(trimKey(key+ext)))
+      .some(key =>
+        extensions.some( ext => moduleName.endsWith(trimKey(key+ext)))
       )
   ) {
     return YES;

--- a/webpack/src/module.js
+++ b/webpack/src/module.js
@@ -13,9 +13,9 @@ var Module = {
       .sort(function(a, b) { return a.length - b.length; });
     var targetFileIndex = targetFile + '/index';
 
-    var asIs = keys.find(function(name) { return name.indexOf(fileName) >= 0; });
-    var asFile = keys.find(function(name) { return name.indexOf(targetFile) >= 0; });
-    var asIndex = keys.find(function(name) { return name.indexOf(targetFileIndex) >= 0; });
+    var asIs = keys.filter(function(name) { return name.indexOf(fileName) >= 0; }).shift();
+    var asFile = keys.filter(function(name) { return name.indexOf(targetFile) >= 0; }).shift();
+    var asIndex = keys.filter(function(name) { return name.indexOf(targetFileIndex) >= 0; }).shift();
 
     if (asFile && asIndex && asFile.substr(targetFile.length + 1).indexOf('/') >= 0) {
       return asIndex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,13 +1224,6 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-assign@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
-  integrity sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-object-rest-spread@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
@@ -1245,6 +1238,13 @@ babel-plugin-transform-regenerator@^6.22.0:
   integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
   dependencies:
     regenerator-transform "^0.10.0"
+
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
This change finally get rewiremock to work with IE11!

### The changes are:
1. Replace Array.prototype.find
    * Use Array.prototype.some to check element existance
    * Use Array.prototype.filter combined with Array.prototype.unshift to get the element

2. Add babel-plugin-transform-runtime to transform Promise and Object.assign
(thus babel-plugin-transform-object-assign is not needed)

3. Replace string.prototype.endsWith with a custom helper function


### Verification
Pass in local IE tests!
