### PR TITLE
fix: move original exports to prototype for callThought

### DIFF
--- a/_tests/lib/d/a-class.js
+++ b/_tests/lib/d/a-class.js
@@ -1,0 +1,6 @@
+class Thing {
+  a() {return 'notmocked-a'}
+  b() {return 'notmocked-b'}
+}
+
+module.exports = new Thing();

--- a/_tests/lib/d/class.js
+++ b/_tests/lib/d/class.js
@@ -1,0 +1,3 @@
+const inst = require('./a-class.js');
+
+module.exports = () => inst.a() + '|' + inst.b();

--- a/_tests/node.spec.js
+++ b/_tests/node.spec.js
@@ -7,7 +7,17 @@ describe('nodejs API', () => {
   it('should partially mock due to callThrough proxy:', () => {
     const mocked = rewiremock.proxy('./lib/d',
       (r) => ({
-        './lib/d/a.js': r.callThrough().with({a:{ toString: () =>'mocked'}}).toBeUsed()
+        './lib/d/a.js': r.callThrough().with({a: {toString: () => 'mocked'}}).toBeUsed()
+      })
+    );
+    expect(mocked()).to.be.equal('mocked|notmocked-b');
+  });
+
+  // https://github.com/theKashey/rewiremock/issues/74
+  it('should partially mock class instance using callThrough proxy:', () => {
+    const mocked = rewiremock.proxy('./lib/d/class',
+      (r) => ({
+        './lib/d/a-class.js': r.callThrough().with({a: () => 'mocked'}).toBeUsed()
       })
     );
     expect(mocked()).to.be.equal('mocked|notmocked-b');

--- a/src/executor.js
+++ b/src/executor.js
@@ -201,7 +201,8 @@ function mockLoader(request, parent, isMain) {
       if (mock.mockThrough) {
         const factory = mock.mockThrough === true ? getScopeOption('stubFactory') : mock.mockThrough;
         mock.override = mockThought(factory || standardStubFactory, mock.original);
-        return mockResult(request, mock, () => Object.assign({},
+        return mockResult(request, mock, () => Object.assign(
+          {},
           mock.override,
           mock.value,
           {__esModule: mock.original.__esModule}
@@ -237,10 +238,9 @@ function mockLoader(request, parent, isMain) {
               + request + '. Use overrideBy instead.');
           }
         }
-        return mockResult(request, mock, () => Object.assign({},
-          mock.original,
+        return mockResult(request, mock, () => Object.assign(
+          Object.create(mock.original),
           mock.value,
-          {__esModule: mock.original.__esModule}
         ));
       }
 


### PR DESCRIPTION
Fixes #74 

Old `callThought` uses `Object.assign` to _squish_ original, mock, magic flags, like {esModules} into a result mock.

New `callThought` moves an original object to the mock prototype, making all "base" values, including `esModules` magically available.

__Might be a breaking change__, if base object defines readonly properties, like `esModules` - override would fail.

^ that's something to be double checked. From one point of view - with es modules it's impossible to define such objects. From another point of view - it's possible for nodejs.