### PR TITLE
fix: migrate to webpack v4 plugin api, fixes #21

### DIFF
--- a/webpack/plugin.js
+++ b/webpack/plugin.js
@@ -18,9 +18,9 @@ const injectString = `/***/if(typeof __webpack_require__!=='undefined') {
 
 class RewiremockPlugin {
   apply(compiler) {
-    compiler.plugin('compilation', function (compilation) {
+    compiler.hooks.compilation.tap('RewiremockPlugin', function (compilation) {
 
-      compilation.moduleTemplate.plugin('render', function (moduleSource) {
+      compilation.moduleTemplates.javascript.hooks.render.tap('RewiremockPlugin', function (moduleSource) {
         const source = new ConcatSource();
         const src = moduleSource.source();
         // and injection


### PR DESCRIPTION
What I did:
- Replaced `.plugin('event', fn)` calls with `.hooks.event.tap(name, fn)`
- Replaced `compilation.moduleTemplate` calls with `compilation.moduleTemplates.javascript`

I have no experience in writing webpack plugins, I just followed the migration guide, so please check if what I did makes sense or if there's something that can be improved with the new api.