### PR TITLE
Finish node wipe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ import {_clearPlugins} from './plugins';
 import plugins from './plugins/index';
 import {getModuleName, getModuleParent} from './module';
 import {setExtensions as resolveExtensions} from './constants';
+import * as API from './mockModule';
+import applyDefaultConfig from "./plugins/defaultConfig";
+
 
 const moduleName = getModuleName(module);
 if (!moduleName) {
@@ -15,22 +18,23 @@ if (!getModuleParent(module)) {
 }
 
 // delete core
-safelyRemoveCache(path.join(path.dirname(__filename), './mockModule.js'));
+API.cleanup();
 // delete self
-safelyRemoveCache(moduleName.replace('index.js', 'mockModule.js'));
-
-import * as API from './mockModule';
-import applyDefaultConfig from "./plugins/defaultConfig";
+safelyRemoveCache(getModuleName(module));
 
 export const cleanup = () => {
   const wipeAll = (stubs, moduleName) => moduleName.indexOf(stubs) === 0;
   wipe(path.dirname(__filename), wipeAll);
 };
 
-export const overrideEntryPoint = (module) => {
-  safelyRemoveCache(getModuleName(module));
-  API.mockModule.overrideEntryPoint(getModuleParent(module));
-  //API.cleanup();
+/**
+ * override "parent" for rewiremock. Will wipe given parent from a cache
+ * by default parent for rewiremock is rewiremock entrypoont, once wrapped - wrapper should set itself as a parent.
+ * @param {Module} parentModule
+ */
+export const overrideEntryPoint = (parentModule) => {
+  safelyRemoveCache(getModuleName(parentModule));
+  API.mockModule.overrideEntryPoint(getModuleParent(parentModule));
 };
 
 overrideEntryPoint(module);

--- a/src/mockModule.js
+++ b/src/mockModule.js
@@ -1,5 +1,5 @@
-import Module, {getModuleParent} from './module';
-import wipeCache from './wipeCache';
+import Module, {getModuleName, getModuleParent} from './module';
+import wipeCache, {safelyRemoveCache} from './wipeCache';
 import createScope from './scope';
 import {getScopeVariable, setScope} from './globals';
 import {
@@ -322,11 +322,12 @@ mockModule.clear = () => {
 };
 
 const cleanup = () => {
-  delete require.cache[require.resolve(__filename)];
+  safelyRemoveCache(getModuleName(module));
 };
 
 
 const addPlugin = (plugin) => {
+  plugin.init();
   scope();
   addPluginAPI(plugin);
 };

--- a/src/module.js
+++ b/src/module.js
@@ -3,6 +3,7 @@ import Module from './getModule';
 
 import executor, {requireModule} from './executor';
 import probeAsyncModules from './asyncModules';
+import {getModuleName, getModuleParent, getModuleParents, moduleCompare} from "./utils/modules";
 
 export const originalLoader = Module._load;
 
@@ -53,8 +54,6 @@ const NodeModule = {
   }
 };
 
-const toModule = (name) => name && require.cache[name];
-
 export const pickModuleName = (fileName, parent) => {
   if (typeof __webpack_modules__ !== 'undefined' && !__webpack_modules__[fileName]) {
     const targetFile = resolve(dirname(getModuleName(parent)), fileName);
@@ -67,11 +66,9 @@ export const pickModuleName = (fileName, parent) => {
   }
 };
 
-export const moduleCompare = (a, b) => a === b || getModuleName(a) === getModuleName(b);
 
-export const getModuleName = (module) => String(module.filename || module.i);
-export const getModuleParent = (module) => module && (module.parent || toModule(module.parents && module.parents[0]));
-export const getModuleParents = (module) => module && (module.parent ? [getModuleName(module.parent)] : module.parents);
+
+export {getModuleName, getModuleParent, getModuleParents, moduleCompare}
 
 export const inParents = (a, b) => {
   const B = getModuleName(b)

--- a/src/nested.js
+++ b/src/nested.js
@@ -1,3 +1,5 @@
 import * as API from './mockModule';
-delete require.cache[require.resolve(__filename)];
+import {safelyRemoveCache} from "./wipeCache";
+import {getModuleName} from "./module";
+safelyRemoveCache(getModuleName(module));
 export default API.mockModule;

--- a/src/plugins/_common.js
+++ b/src/plugins/_common.js
@@ -6,11 +6,11 @@ const PASS = true;
 
 const onetoone = a => a;
 const pass = () => PASS;
-
-
+const empty = () => null;
 
 const createPlugin = (plugin) => {
     const result = Object.assign({
+        init: empty,
         fileNameTransformer: onetoone,
         wipeCheck: pass,
         shouldMock: pass,

--- a/src/plugins/node-lib-browser.js
+++ b/src/plugins/node-lib-browser.js
@@ -1,10 +1,14 @@
-import mapping from 'node-libs-browser';
-
 import createPlugin from './_common';
 
+let mapping;
+
+const init = () => {
+  mapping = require('node-libs-browser');
+}
 const fileNameTransformer = (fileName/*, module*/) => mapping[fileName] || fileName;
 
 const plugin = createPlugin({
+  init,
   fileNameTransformer,
   //wipeCheck,
   //shouldMock,

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -1,0 +1,5 @@
+export const toModule = (name) => name && require.cache[name];
+export const getModuleName = (module) => String(module.filename || module.i);
+export const getModuleParent = (module) => module && (module.parent || toModule(module.parents && module.parents[0]));
+export const getModuleParents = (module) => module && (module.parent ? [getModuleName(module.parent)] : module.parents);
+export const moduleCompare = (a, b) => a === b || getModuleName(a) === getModuleName(b);

--- a/src/wipeCache.js
+++ b/src/wipeCache.js
@@ -2,7 +2,6 @@ import {getAllMocks} from './mocks';
 import {shouldWipe} from './plugins'
 import {relativeWipeCheck} from "./plugins/relative";
 import Module from './module';
-import {toModule} from "./utils/modules";
 
 // which one?
 export const wipe = typeof __webpack_require__ === 'function'


### PR DESCRIPTION
- Replacing direct cleanup by `safeWipe`. Removes `require.resolve` from the code and improve cache management
- Adding `init` event for plugins to not execute `nodeLibBrowser` one.